### PR TITLE
Skaffold Setup

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
+from socket import gethostname, gethostbyname
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -26,6 +27,7 @@ SECRET_KEY = "u052ixbr8xoew*b3q*ozn4dg(ud#x!kuz-wfa=7%m49wj_ud7o"
 DEBUG = True
 
 ALLOWED_HOSTS = [
+    '10.211.55.8',
     "localhost",
     "server",
 ]
@@ -83,7 +85,7 @@ DATABASES = {
         "NAME": "postgres",
         "USER": "postgres",
         "PASSWORD": "secret",
-        "HOST": "db",
+        "HOST": "commenting-system-postgresql-headless",
         "PORT": "",
     },
 }
@@ -114,7 +116,6 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/

--- a/app/settings.py
+++ b/app/settings.py
@@ -27,7 +27,7 @@ SECRET_KEY = "u052ixbr8xoew*b3q*ozn4dg(ud#x!kuz-wfa=7%m49wj_ud7o"
 DEBUG = True
 
 ALLOWED_HOSTS = [
-    '10.211.55.8',
+    "10.211.55.8",
     "localhost",
     "server",
 ]

--- a/app/settings.py
+++ b/app/settings.py
@@ -9,8 +9,9 @@ https://docs.djangoproject.com/en/2.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
-
+import json
 import os
+
 from socket import gethostname, gethostbyname
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -26,12 +27,7 @@ SECRET_KEY = "u052ixbr8xoew*b3q*ozn4dg(ud#x!kuz-wfa=7%m49wj_ud7o"
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = [
-    "10.211.55.8",
-    "localhost",
-    "server",
-]
-
+ALLOWED_HOSTS = [os.getenv("HOST")]
 
 # Application definition
 
@@ -82,11 +78,11 @@ WSGI_APPLICATION = "app.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "postgres",
-        "USER": "postgres",
-        "PASSWORD": "secret",
-        "HOST": "commenting-system-postgresql-headless",
-        "PORT": "",
+        "HOST": os.getenv("DATABASE_HOST"),
+        "NAME": os.getenv("DATABASE_NAME"),
+        "USER": os.getenv("DATABASE_USER"),
+        "PASSWORD": os.getenv("DATABASE_PASSWORD"),
+        "PORT": os.getenv("DATABASE_PORT"),
     },
 }
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,9 +1,13 @@
 FROM python:3.8-alpine
 
 WORKDIR /usr/src/app
-RUN apk update && apk add librdkafka-dev postgresql-libs gcc musl-dev postgresql-dev
+RUN apk update && apk add librdkafka-dev gcc musl-dev postgresql-dev postgresql-libs
 COPY requirements.txt .
 RUN pip install --requirement requirements.txt
+COPY app app
+COPY pact pact
+COPY threads threads
+COPY manage.py .
 
 EXPOSE 8000
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
-name: commenting-system
+name: comments
 version: 0.1.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: commenting-system
+version: 0.1.0

--- a/helm/requirements.lock
+++ b/helm/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 7.7.2
+digest: sha256:455152d08f57c4151fbc0bcccea10bfaa638998af25da6f655c679b008ae0b2e
+generated: "2019-12-08T01:32:31.548709+01:00"

--- a/helm/requirements.lock
+++ b/helm/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 7.7.2
-digest: sha256:455152d08f57c4151fbc0bcccea10bfaa638998af25da6f655c679b008ae0b2e
-generated: "2019-12-08T01:32:31.548709+01:00"
+digest: sha256:4ff0442ce0d0c1602a87652a36c105b17858168f1581dd9b4c373f34bb385043
+generated: "2019-12-10T04:14:14.01771+01:00"

--- a/helm/requirements.yaml
+++ b/helm/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
   - name: postgresql
     version: 7.x
     repository: https://kubernetes-charts.storage.googleapis.com
+    condition: postgresql.enabled

--- a/helm/requirements.yaml
+++ b/helm/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: postgresql
+    version: 7.x
+    repository: https://kubernetes-charts.storage.googleapis.com

--- a/helm/templates.bkup/service.yaml
+++ b/helm/templates.bkup/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "helm.fullname" . }}
+  labels:
+{{ include "helm.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "helm.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "commenting-system.name" -}}
+{{- define "comments.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -9,7 +9,72 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "commenting-system.fullname" -}}
+{{- define "comments.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Default labels to be used for resources
+*/}}
+{{- define "comments.labels" }}
+app: {{ template "comments.name" . }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Database host depending on whether an external database is used
+*/}}
+{{- define "comments.database.host" -}}
+{{- if .Values.postgresql.enabled -}}
+{{ $.Release.Name }}-postgresql-headless
+{{- else -}}
+{{- .Values.externalPostgresql.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Database port depending on whether an external database is used
+*/}}
+{{- define "comments.database.port" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.service.port -}}
+{{- else -}}
+{{- .Values.externalPostgresql.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Database name depending on whether an external database is used
+*/}}
+{{- define "comments.database.name" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.postgresqlDatabase -}}
+{{- else -}}
+{{- .Values.externalPostgresql.database -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Database user depending on whether an external database is used
+*/}}
+{{- define "comments.database.user" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.postgresqlUsername -}}
+{{- else -}}
+{{- .Values.externalPostgresql.username -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Database password depending on whether an external database is used
+*/}}
+{{- define "comments.database.password" }}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.postgresqlPassword -}}
+{{- else -}}
+{{- .Values.externalPostgresql.password -}}
+{{- end -}}
 {{- end -}}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "commenting-system.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "commenting-system.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/templates/database-secret.yml
+++ b/helm/templates/database-secret.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-database
+  labels:
+    {{ include "comments.labels" . | indent 4 }}
+type: Opaque
+stringData:
+  host: {{ include "comments.database.host" . | quote }}
+  port: {{ include "comments.database.port" . | quote }}
+  name: {{ include "comments.database.name" . | quote }}
+  user: {{ include "comments.database.user" . | quote }}
+  password: {{ include "comments.database.password" . | quote }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,41 +1,76 @@
+{{/*
+Environment variables used by containers. Includes configuration used by Django
+*/}}
+{{- define "comments.deployment.env" }}
+- name: DATABASE_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-database
+      key: host
+- name: DATABASE_PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-database
+      key: port
+- name: DATABASE_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-database
+      key: name
+- name: DATABASE_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-database
+      key: user
+- name: DATABASE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-database
+      key: password
+- name: HOST
+  value: {{ .Values.host | quote }}
+{{- end }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}
   labels:
-    app: {{ template "commenting-system.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{ include "comments.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "commenting-system.name" . }}
+      app: {{ template "comments.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:
-        app: {{ template "commenting-system.name" . }}
-        release: {{ .Release.Name }}
+        {{ include "comments.labels" . | indent 8 }}
     spec:
       initContainers:
         - name: init-database
-          image: busybox:1.28
+          image: 'postgres:{{.Values.postgresql.image.tag}}'
           imagePullPolicy: {{ .Values.pullPolicy }}
-          command: ['sh', '-c', 'until nslookup commenting-system-postgresql-headless; do echo waiting for database; sleep 2; done']
+          command: ['sh', '-c', 'until pg_isready --host $DATABASE_HOST --port $DATABASE_PORT; do echo waiting for database; sleep 2; done']
+          env:
+            {{ include "comments.deployment.env" . | indent 12 }}
         - name: init-migrate
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           command: ['python', 'manage.py', 'migrate']
+          env:
+            {{ include "comments.deployment.env" . | indent 12 }}
       containers:
-        - name: commenting-system
+        - name: server
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.service.internalPort }}
+            - containerPort: 8000
           resources:
             {{- toYaml .Values.resources | indent 12 }}
+          env:
+            {{ include "comments.deployment.env" . | indent 12 }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | indent 8 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ template "commenting-system.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "commenting-system.name" . }}
+      release: {{ .Release.Name }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "commenting-system.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      initContainers:
+        - name: init-database
+          image: busybox:1.28
+          imagePullPolicy: {{ .Values.pullPolicy }}
+          command: ['sh', '-c', 'until nslookup commenting-system-postgresql-headless; do echo waiting for database; sleep 2; done']
+        - name: init-migrate
+          image: {{ .Values.image }}
+          imagePullPolicy: {{ .Values.pullPolicy }}
+          command: ['python', 'manage.py', 'migrate']
+      containers:
+        - name: commenting-system
+          image: {{ .Values.image }}
+          imagePullPolicy: {{ .Values.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.internalPort }}
+          resources:
+            {{- toYaml .Values.resources | indent 12 }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,31 +1,26 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "commenting-system.fullname" . -}}
-{{- $servicePort := .Values.service.externalPort -}}
+{{- $serviceName := include "comments.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "commenting-system.fullname" . }}
+  name: {{ template "comments.fullname" . }}
   labels:
-    app: {{ template "commenting-system.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{ include "comments.labels" . | indent 4 }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   rules:
-    {{- if .Values.ingress.hosts }}
-    {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host }}
+    {{- if .Values.host }}
+    - host: {{ .Values.host }}
       http:
         paths:
           - path: /
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
-    {{- end -}}
     {{- else }}
     - http:
         paths:

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "commenting-system.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "commenting-system.fullname" . }}
+  labels:
+    app: {{ template "commenting-system.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- if .Values.ingress.hosts }}
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+    {{- else }}
+    - http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "commenting-system.fullname" . }}
+  labels:
+    app: {{ template "commenting-system.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.service.internalPort }}
+      protocol: TCP
+      name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "commenting-system.name" . }}
+    release: {{ .Release.Name }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,19 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "commenting-system.fullname" . }}
+  name: {{ template "comments.fullname" . }}
   labels:
-    app: {{ template "commenting-system.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{ include "comments.labels" . | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.externalPort }}
-      targetPort: {{ .Values.service.internalPort }}
+    - port: {{ .Values.service.port }}
       protocol: TCP
-      name: {{ .Values.service.name }}
   selector:
-    app: {{ template "commenting-system.name" . }}
+    app: {{ template "comments.name" . }}
     release: {{ .Release.Name }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,41 +1,48 @@
-# Default values for skaffold-helm.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+image:
+  # Image repository
+  repository: nil
+  # Image tag
+  tag: nil
+  # Image pull policy
+  pullPolicy: IfNotPresent
+# Hostname for comments service. Also used for ingress (if enabled)
+host: nil
+# Number of replicas to run
 replicaCount: 1
-# This is the helm convention on declaring images
-# image:
-#   repository: nginx
-#   tag: stable
-#   pullPolicy: IfNotPresent
-service:
-  name: nginx
-  type: NodePort
-  externalPort: 8000
-  internalPort: 8000
-ingress:
-  enabled: true
-  # Used to create an Ingress record.
-  hosts:
-    # - chart-example.local
-  annotations:
-     kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  tls:
-    # Secrets must be manually created in the namespace.
-    # - secretName: chart-example-tls
-    #   hosts:
-    #     - chart-example.local
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
 
 postgresql:
-  postgresqlPassword: secret
+  # Enable or disable PostgreSQL dependency. Refer to [stable/postgresql](https://github.com/helm/charts/tree/master/stable/postgresql) for more information
+  enabled: false
+  image:
+    tag: 9.6
+  postgresqlDatabase: postgres
+  postgresqlUsername: postgres
+  postgresqlPassword: postgres
+  service:
+    port: 5432
+
+# PostgreSQL settings when using externally provisioned PostgreSQL
+externalPostgresql:
+  host: nil
+  port: nil
+  database: nil
+  username: nil
+  password: nil
+
+service:
+  # The service type to use
+  type: ClusterIP
+  # The service port
+  port: 8000
+
+# Pod resource requests and limits
+resources: {}
+
+ingress:
+  # If true, an ingress is created
+  enabled: true
+  # Annotations for the ingress
+  annotations:
+     kubernetes.io/ingress.class: nginx
+  # A list of IngressTLS items
+  tls:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,41 @@
+# Default values for skaffold-helm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+# This is the helm convention on declaring images
+# image:
+#   repository: nginx
+#   tag: stable
+#   pullPolicy: IfNotPresent
+service:
+  name: nginx
+  type: NodePort
+  externalPort: 8000
+  internalPort: 8000
+ingress:
+  enabled: true
+  # Used to create an Ingress record.
+  hosts:
+    # - chart-example.local
+  annotations:
+     kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+postgresql:
+  postgresqlPassword: secret

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "Apache-2.0",
   "author": "Serlo Education e.V.",
   "scripts": {
+    "start": "skaffold dev",
     "format": "npm-run-all format:*",
     "format:prettier": "yarn _prettier --write",
     "format:py": "docker-compose run --rm format",

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -24,5 +24,5 @@ deploy:
         values:
           image: eu.gcr.io/serlo-shared/comments
         setValues:
-          host: comments.serlo.localhost
+          host: comments.serlo.local
           postgresql.enabled: true

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,11 +4,16 @@ build:
   tagPolicy:
     sha256: {}
   artifacts:
-    - image: eu.gcr.io/serlo-shared/commenting-system
+    - image: eu.gcr.io/serlo-shared/comments
+      docker:
+        dockerfile: ./docker/server/Dockerfile
 deploy:
   helm:
     releases:
-      - name: commenting-system
+      - name: comments
         chartPath: helm
         values:
-          image: eu.gcr.io/serlo-shared/commenting-system
+          image: eu.gcr.io/serlo-shared/comments
+        setValues:
+          host: comments.serlo.localhost
+          postgresql.enabled: true

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v1
+kind: Config
+build:
+  tagPolicy:
+    sha256: {}
+  artifacts:
+    - image: eu.gcr.io/serlo-shared/commenting-system
+deploy:
+  helm:
+    releases:
+      - name: commenting-system
+        chartPath: helm
+        values:
+          image: eu.gcr.io/serlo-shared/commenting-system

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -3,11 +3,20 @@ kind: Config
 build:
   tagPolicy:
     sha256: {}
+  local:
+    push: false
   artifacts:
     - image: eu.gcr.io/serlo-shared/comments
       docker:
         dockerfile: ./docker/server/Dockerfile
+      sync:
+        infer:
+          - app/**/*
+          - pact/**/*
+          - threads/**/*
+          - manage.py
 deploy:
+  kubeContext: minikube
   helm:
     releases:
       - name: comments


### PR DESCRIPTION
## Setup
- Install [Minikube](https://minikube.sigs.k8s.io/)
- Install [Skaffold](https://skaffold.dev/docs/install/)
- `minikube addons enable ingress`
- Install [Helm **v2**](https://v2.helm.sh/docs/using_helm/#installing-helm)
- `minikube start --extra-config=apiserver.service-node-port-range=1-65535`
- `helm init`
- Add a local DNS rule that resolves `comments.serlo.local` to Minikube, i.e.
    - add the following line to `/etc/hosts` (Linux & macOS) resp. `C:\Windows\System32\drivers\etc\hosts.txt` (Windows):
        ```
        10.211.55.8     comments.serlo.local
        ```
        where `10.211.55.8` is the ip address returned by `minikube ip` **OR**
    - use https://github.com/cbednarski/hostess and execute
        ```
        hostess add comments.serlo.local $(minikube ip)
        ```
- `skaffold dev`
- Open `http://comments.serlo.local`

## Open stuff
- [ ] How to run `black` to format source code?
  - Maybe still require docker as a "task runner"? This allows us to run pretty much arbitrary binaries in docker w/o requiring some external setup (e.g. we could even run `prettier` in docker). `yarn` resp. `make` could be optional aliases to `docker-compose run TASK`
  - This would also allow us to configure IntelliJ to use Docker for Python / PHP so we don't need a local setup, too.
- [ ] Can we automate the needed changes to `/etc/hosts`?
- [ ] Does this work on linux
- [ ] Add Kafka to helm chart
- [ ] Add Worker to helm chart
- [ ] Add README
- [ ] Add Pact verifier